### PR TITLE
Make classes more friendly for end-user extensibility

### DIFF
--- a/lib/AccountsService.php
+++ b/lib/AccountsService.php
@@ -11,7 +11,7 @@ namespace BaseCRM;
  */
 class AccountsService
 {
-  private $httpClient;
+  protected $httpClient;
 
   /**
    * Instantiate a new AccountsService instance.

--- a/lib/AssociatedContactsService.php
+++ b/lib/AssociatedContactsService.php
@@ -12,9 +12,9 @@ namespace BaseCRM;
 class AssociatedContactsService
 {
   // @var array Allowed attribute names.
-  private static $keysToPersist = ['contact_id', 'role'];
+  protected static $keysToPersist = ['contact_id', 'role'];
 
-  private $httpClient;
+  protected $httpClient;
 
   /**
    * Instantiate a new AssociatedContactsService instance.

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -15,7 +15,7 @@ class Client
    * @var \BaseCRM\HttpClient Http client
    * @ignore 
    */
-  private $httpClient;
+  protected $httpClient;
 
   /**
    * @var \BaseCRM\Configuration Client configuratation

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -100,7 +100,7 @@ class Configuration
   /**
    * @ignore
    */
-  private function _accessTokenIsMissing()
+  protected function _accessTokenIsMissing()
   {
     $msg = 'No access token provided. '
       . 'Set your access token during client initialization using: '

--- a/lib/ContactsService.php
+++ b/lib/ContactsService.php
@@ -12,9 +12,9 @@ namespace BaseCRM;
 class ContactsService
 {
   // @var array Allowed attribute names.
-  private static $keysToPersist = ['address', 'contact_id', 'custom_fields', 'customer_status', 'description', 'email', 'facebook', 'fax', 'first_name', 'industry', 'is_organization', 'last_name', 'linkedin', 'mobile', 'name', 'owner_id', 'phone', 'prospect_status', 'skype', 'tags', 'title', 'twitter', 'website'];
+  protected static $keysToPersist = ['address', 'contact_id', 'custom_fields', 'customer_status', 'description', 'email', 'facebook', 'fax', 'first_name', 'industry', 'is_organization', 'last_name', 'linkedin', 'mobile', 'name', 'owner_id', 'phone', 'prospect_status', 'skype', 'tags', 'title', 'twitter', 'website'];
 
-  private $httpClient;
+  protected $httpClient;
 
   /**
    * Instantiate a new ContactsService instance.

--- a/lib/DealsService.php
+++ b/lib/DealsService.php
@@ -12,9 +12,9 @@ namespace BaseCRM;
 class DealsService
 {
   // @var array Allowed attribute names.
-  private static $keysToPersist = ['contact_id', 'currency', 'custom_fields', 'estimated_close_date', 'hot', 'loss_reason_id', 'name', 'owner_id', 'source_id', 'stage_id', 'tags', 'value'];
+  protected static $keysToPersist = ['contact_id', 'currency', 'custom_fields', 'estimated_close_date', 'hot', 'loss_reason_id', 'name', 'owner_id', 'source_id', 'stage_id', 'tags', 'value'];
 
-  private $httpClient;
+  protected $httpClient;
 
   /**
    * Instantiate a new DealsService instance.

--- a/lib/Errors/ConnectionError.php
+++ b/lib/Errors/ConnectionError.php
@@ -5,7 +5,7 @@ use Exception;
 
 class ConnectionError extends Exception
 {
-  private $errno, $error_message;
+  protected $errno, $error_message;
 
   public function __construct($errno, $error_message)
   {

--- a/lib/HttpClient.php
+++ b/lib/HttpClient.php
@@ -7,7 +7,7 @@ class HttpClient
   const API_VERSION_PREFIX = "/v2"; 
     
   // @ignore
-  private $config;
+  protected $config;
 
   public function __construct(Configuration $config)
   {
@@ -172,7 +172,7 @@ class HttpClient
    *
    * @ignore
    */
-  private function wrapEnvelope(array $body)
+  protected function wrapEnvelope(array $body)
   {
     return ['data' => $body];
   }
@@ -185,7 +185,7 @@ class HttpClient
    *
    * @ignore
    */
-  private function unwrapEnvelope(array $body)
+  protected function unwrapEnvelope(array $body)
   {
     if (isset($body['data']))
     {
@@ -216,7 +216,7 @@ class HttpClient
    *
    * @ignore
    */
-  private function handleResponse($code, $rawResponse)
+  protected function handleResponse($code, $rawResponse)
   {
     try 
     {
@@ -241,7 +241,7 @@ class HttpClient
   /**
    * @ignore
    */
-  private function handleErrorResponse($code, $rawResponse, $response)
+  protected function handleErrorResponse($code, $rawResponse, $response)
   {
     switch(true)
     {

--- a/lib/LeadsService.php
+++ b/lib/LeadsService.php
@@ -12,9 +12,9 @@ namespace BaseCRM;
 class LeadsService
 {
   // @var array Allowed attribute names.
-  private static $keysToPersist = ['address', 'custom_fields', 'description', 'email', 'facebook', 'fax', 'first_name', 'industry', 'last_name', 'linkedin', 'mobile', 'organization_name', 'owner_id', 'phone', 'skype', 'source_id', 'status', 'tags', 'title', 'twitter', 'website'];
+  protected static $keysToPersist = ['address', 'custom_fields', 'description', 'email', 'facebook', 'fax', 'first_name', 'industry', 'last_name', 'linkedin', 'mobile', 'organization_name', 'owner_id', 'phone', 'skype', 'source_id', 'status', 'tags', 'title', 'twitter', 'website'];
 
-  private $httpClient;
+  protected $httpClient;
 
   /**
    * Instantiate a new LeadsService instance.

--- a/lib/LossReasonsService.php
+++ b/lib/LossReasonsService.php
@@ -12,9 +12,9 @@ namespace BaseCRM;
 class LossReasonsService
 {
   // @var array Allowed attribute names.
-  private static $keysToPersist = ['name'];
+  protected static $keysToPersist = ['name'];
 
-  private $httpClient;
+  protected $httpClient;
 
   /**
    * Instantiate a new LossReasonsService instance.

--- a/lib/NotesService.php
+++ b/lib/NotesService.php
@@ -12,9 +12,9 @@ namespace BaseCRM;
 class NotesService
 {
   // @var array Allowed attribute names.
-  private static $keysToPersist = ['content', 'resource_id', 'resource_type'];
+  protected static $keysToPersist = ['content', 'resource_id', 'resource_type'];
 
-  private $httpClient;
+  protected $httpClient;
 
   /**
    * Instantiate a new NotesService instance.

--- a/lib/PipelinesService.php
+++ b/lib/PipelinesService.php
@@ -11,7 +11,7 @@ namespace BaseCRM;
  */
 class PipelinesService
 {
-  private $httpClient;
+  protected $httpClient;
 
   /**
    * Instantiate a new PipelinesService instance.

--- a/lib/SourcesService.php
+++ b/lib/SourcesService.php
@@ -12,9 +12,9 @@ namespace BaseCRM;
 class SourcesService
 {
   // @var array Allowed attribute names.
-  private static $keysToPersist = ['name'];
+  protected static $keysToPersist = ['name'];
 
-  private $httpClient;
+  protected $httpClient;
 
   /**
    * Instantiate a new SourcesService instance.

--- a/lib/StagesService.php
+++ b/lib/StagesService.php
@@ -11,7 +11,7 @@ namespace BaseCRM;
  */
 class StagesService
 {
-  private $httpClient;
+  protected $httpClient;
 
   /**
    * Instantiate a new StagesService instance.

--- a/lib/Sync.php
+++ b/lib/Sync.php
@@ -25,13 +25,13 @@ class Sync
    * @var string Device's UUID.
    * @ignore
    */
-  private $deviceUUID;
+  protected $deviceUUID;
 
   /**
    * @var \BaseCRM\Client BaseCRM client.
    * @ignore
    */
-  private $client;
+  protected $client;
 
   /**
    * Instantiate a new high-level Sync wrapper instance.

--- a/lib/SyncService.php
+++ b/lib/SyncService.php
@@ -11,7 +11,7 @@ namespace BaseCRM;
  */
 class SyncService
 {
-  private $httpClient;
+  protected $httpClient;
 
   /**
    * Instantiate a new SyncService instance.
@@ -108,7 +108,7 @@ class SyncService
    *
    * @ignore
    */
-  private function checkArgument($argument, $argumentName)
+  protected function checkArgument($argument, $argumentName)
   {
     if (!is_string($argument) || !trim($argument)) 
       throw new InvalidArgumentException("{$argumentName} argument must be a non-empty string. Input was: {$argument}");
@@ -119,7 +119,7 @@ class SyncService
    *
    * @ignore
    */
-  private function buildHeaders($deviceUUID)
+  protected function buildHeaders($deviceUUID)
   {
     return ['X-Basecrm-Device-UUID' => $deviceUUID];
   }

--- a/lib/TagsService.php
+++ b/lib/TagsService.php
@@ -12,9 +12,9 @@ namespace BaseCRM;
 class TagsService
 {
   // @var array Allowed attribute names.
-  private static $keysToPersist = ['name', 'resource_type'];
+  protected static $keysToPersist = ['name', 'resource_type'];
 
-  private $httpClient;
+  protected $httpClient;
 
   /**
    * Instantiate a new TagsService instance.

--- a/lib/TasksService.php
+++ b/lib/TasksService.php
@@ -12,9 +12,9 @@ namespace BaseCRM;
 class TasksService
 {
   // @var array Allowed attribute names.
-  private static $keysToPersist = ['completed', 'content', 'due_date', 'owner_id', 'remind_at', 'resource_id', 'resource_type'];
+  protected static $keysToPersist = ['completed', 'content', 'due_date', 'owner_id', 'remind_at', 'resource_id', 'resource_type'];
 
-  private $httpClient;
+  protected $httpClient;
 
   /**
    * Instantiate a new TasksService instance.

--- a/lib/UsersService.php
+++ b/lib/UsersService.php
@@ -11,7 +11,7 @@ namespace BaseCRM;
  */
 class UsersService
 {
-  private $httpClient;
+  protected $httpClient;
 
   /**
    * Instantiate a new UsersService instance.


### PR DESCRIPTION
Making properties/methods `protected` instead of `private` allows for much more user-extensibility by your customers :)