### PR TITLE
Improve the phpunit command line example

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,13 +364,13 @@ $ composer install
 To run all test suites:
 
 ```bash
-$ ./vendor/bin/phpunit
+$ BASECRM_ACCESS_TOKEN=<your-token-here> ./vendor/bin/phpunit
 ```
 
 And to run a single suite:
 
 ```bash
-$ ./vendor/bin/phpunit --filter testUpdate tests/LeadsServiceTest.php 
+$ BASECRM_ACCESS_TOKEN=<your-token-here> ./vendor/bin/phpunit --filter testUpdate tests/LeadsServiceTest.php 
 ```
 
 ## License


### PR DESCRIPTION
Update unit testing command line to define the access token needed for running the tests.