### PR TITLE
Update ConfigurationError.php

### DIFF
--- a/lib/Errors/ConfigurationError.php
+++ b/lib/Errors/ConfigurationError.php
@@ -5,8 +5,16 @@ use Exception;
 
 class ConfigurationError extends Exception
 {
+  protected $error_message;
+  
   public function __construct($message)
   {
     parent::__construct($message);
+    $this->error_message = $message;
+  }
+
+  public function getErrorMessage()
+  {
+    return $this->error_message;
   }
 }


### PR DESCRIPTION
issue: error handling is not working, no way to get error message when access token is not valid.

using sample code from https://github.com/basecrm/basecrm-php#error-handling

	catch (\BaseCRM\Errors\ConfigurationError $e)
	{
	  	// Invalid client configuration option
		print($e->getErrorMessage());
	}

it is giving 
PHP Fatal error:  Uncaught Error: Call to undefined method BaseCRM\Errors\ConfigurationError::getErrorMessage()
instead of
"Provided access token is invalid as it contains disallowed characters. Please double-check your access token."

So in order to see that message need to extend ConfigurationError class with getErrorMessage().

Thanks!