### PR TITLE
Value is optional for deals

### DIFF
--- a/lib/DealsService.php
+++ b/lib/DealsService.php
@@ -60,7 +60,7 @@ class DealsService
     $attributes = array_intersect_key($deal, array_flip(self::$keysToPersist));
     if (isset($attributes['custom_fields']) && empty($attributes['custom_fields'])) unset($attributes['custom_fields']);
  
-    $attributes["value"] = Coercion::toStringValue($attributes['value']);
+    if (isset($attributes['value'])) $attributes["value"] = Coercion::toStringValue($attributes['value']);
     list($code, $createdDeal) = $this->httpClient->post("/deals", $attributes);
     $createdDeal = $this->coerceDealData($createdDeal);
     return $createdDeal;


### PR DESCRIPTION
Fixes #21

Value is not required to create a Deal. Currently if `value` is not provided it fails due to missing key in `$attributes`.

The original issue said that this was fixed but I could still reproduce it in `v1.4.0`.