### PR TITLE
Allow clients to pass $raw option

### DIFF
--- a/lib/AccountsService.php
+++ b/lib/AccountsService.php
@@ -31,11 +31,13 @@ class AccountsService
    * Returns detailed information about your account
    *
    *
+   * @param array $options Additional request's options.
+   *
    * @return array Resource object.
    */
-  public function self()
+  public function self(array $options = array())
   {
-    list($code, $resource) = $this->httpClient->get("/accounts/self");
+    list($code, $resource) = $this->httpClient->get("/accounts/self", null, $options);
     return $resource;
   }
 }

--- a/lib/AssociatedContactsService.php
+++ b/lib/AssociatedContactsService.php
@@ -34,13 +34,14 @@ class AssociatedContactsService
    * Returns all deal associated contacts
    *
    * @param integer $deal_id Unique identifier of a Deal
-   * @param array $options Search options
+   * @param array $params Search options
+   * @param array $options Additional request's options.
    *
    * @return array The list of AssociatedContacts for the first page, unless otherwise specified.
    */
-  public function all($deal_id, $options = [])
+  public function all($deal_id, $params = [], array $options = array())
   {
-    list($code, $associated_contacts) = $this->httpClient->get("/deals/{$deal_id}/associated_contacts", $options);
+    list($code, $associated_contacts) = $this->httpClient->get("/deals/{$deal_id}/associated_contacts", $params, $options);
     return $associated_contacts;
   }
 
@@ -54,14 +55,15 @@ class AssociatedContactsService
    *
    * @param integer $deal_id Unique identifier of a Deal
    * @param array $associatedContact This array's attributes describe the object to be created.
+   * @param array $options Additional request's options.
    *
    * @return array The resulting object representing created resource.
    */
-  public function create($deal_id, array $associatedContact)
+  public function create($deal_id, array $associatedContact, array $options = array())
   {
     $attributes = array_intersect_key($associatedContact, array_flip(self::$keysToPersist));
 
-    list($code, $createdAssociatedContact) = $this->httpClient->post("/deals/{$deal_id}/associated_contacts", $attributes);
+    list($code, $createdAssociatedContact) = $this->httpClient->post("/deals/{$deal_id}/associated_contacts", $attributes, $options);
     return $createdAssociatedContact;
   }
 
@@ -76,12 +78,13 @@ class AssociatedContactsService
    *
    * @param integer $deal_id Unique identifier of a Deal
    * @param integer $contact_id Unique identifier of a Contact
+   * @param array $options Additional request's options.
    *
    * @return boolean Status of the operation.
    */
-  public function destroy($deal_id, $contact_id)
+  public function destroy($deal_id, $contact_id, array $options = array())
   {
-    list($code, $payload) = $this->httpClient->delete("/deals/{$deal_id}/associated_contacts/{$contact_id}");
+    list($code, $payload) = $this->httpClient->delete("/deals/{$deal_id}/associated_contacts/{$contact_id}", null, $options);
     return $code == 204;
   }
 }

--- a/lib/ContactsService.php
+++ b/lib/ContactsService.php
@@ -33,13 +33,14 @@ class ContactsService
    *
    * Returns all contacts available to the user according to the parameters provided
    *
-   * @param array $options Search options
+   * @param array $params Search options
+   * @param array $options Additional request's options.
    *
    * @return array The list of Contacts for the first page, unless otherwise specified.
    */
-  public function all($options = [])
+  public function all($params = [], array $options = array())
   {
-    list($code, $contacts) = $this->httpClient->get("/contacts", $options);
+    list($code, $contacts) = $this->httpClient->get("/contacts", $params, $options);
     return $contacts;
   }
 
@@ -52,15 +53,16 @@ class ContactsService
    * A contact may represent a single individual or an organization
    *
    * @param array $contact This array's attributes describe the object to be created.
+   * @param array $options Additional request's options.
    *
    * @return array The resulting object representing created resource.
    */
-  public function create(array $contact)
+  public function create(array $contact, array $options = array())
   {
     $attributes = array_intersect_key($contact, array_flip(self::$keysToPersist));
     if (isset($attributes['custom_fields']) && empty($attributes['custom_fields'])) unset($attributes['custom_fields']);
 
-    list($code, $createdContact) = $this->httpClient->post("/contacts", $attributes);
+    list($code, $createdContact) = $this->httpClient->post("/contacts", $attributes, $options);
     return $createdContact;
   }
 
@@ -73,12 +75,13 @@ class ContactsService
    * If the specified contact does not exist, the request will return an error
    *
    * @param integer $id Unique identifier of a Contact
+   * @param array $options Additional request's options.
    *
    * @return array Searched Contact.
    */
-  public function get($id)
+  public function get($id, array $options = array())
   {
-    list($code, $contact) = $this->httpClient->get("/contacts/{$id}");
+    list($code, $contact) = $this->httpClient->get("/contacts/{$id}", null, $options);
     return $contact;
   }
 
@@ -94,15 +97,16 @@ class ContactsService
    *
    * @param integer $id Unique identifier of a Contact
    * @param array $contact This array's attributes describe the object to be updated.
+   * @param array $options Additional request's options.
    *
    * @return array The resulting object representing updated resource.
    */
-  public function update($id, array $contact)
+  public function update($id, array $contact, array $options = array())
   {
     $attributes = array_intersect_key($contact, array_flip(self::$keysToPersist));
     if (isset($attributes['custom_fields']) && empty($attributes['custom_fields'])) unset($attributes['custom_fields']);
 
-    list($code, $updatedContact) = $this->httpClient->put("/contacts/{$id}", $attributes);
+    list($code, $updatedContact) = $this->httpClient->put("/contacts/{$id}", $attributes, $options);
     return $updatedContact;
   }
 
@@ -116,12 +120,13 @@ class ContactsService
    * This operation cannot be undone
    *
    * @param integer $id Unique identifier of a Contact
+   * @param array $options Additional request's options.
    *
    * @return boolean Status of the operation.
    */
-  public function destroy($id)
+  public function destroy($id, array $options = array())
   {
-    list($code, $payload) = $this->httpClient->delete("/contacts/{$id}");
+    list($code, $payload) = $this->httpClient->delete("/contacts/{$id}", null, $options);
     return $code == 204;
   }
 }

--- a/lib/DealSourcesService.php
+++ b/lib/DealSourcesService.php
@@ -33,13 +33,14 @@ class DealSourcesService
    *
    * Returns all deal sources available to the user according to the parameters provided
    *
-   * @param array $options Search options
+   * @param array $params Search options
+   * @param array $options Additional request's options.
    *
    * @return array The list of DealSources for the first page, unless otherwise specified.
    */
-  public function all($options = [])
+  public function all($params = [], array $options = array())
   {
-    list($code, $deal_sources) = $this->httpClient->get("/deal_sources", $options);
+    list($code, $deal_sources) = $this->httpClient->get("/deal_sources", $params, $options);
     return $deal_sources;
   }
 
@@ -54,14 +55,15 @@ class DealSourcesService
    * </figure>
    *
    * @param array $dealSource This array's attributes describe the object to be created.
+   * @param array $options Additional request's options.
    *
    * @return array The resulting object representing created resource.
    */
-  public function create(array $dealSource)
+  public function create(array $dealSource, array $options = array())
   {
     $attributes = array_intersect_key($dealSource, array_flip(self::$keysToPersist));
 
-    list($code, $createdDealSource) = $this->httpClient->post("/deal_sources", $attributes);
+    list($code, $createdDealSource) = $this->httpClient->post("/deal_sources", $attributes, $options);
     return $createdDealSource;
   }
 
@@ -74,12 +76,13 @@ class DealSourcesService
    * If a source with the supplied unique identifier does not exist it returns an error
    *
    * @param integer $id Unique identifier of a DealSource
+   * @param array $options Additional request's options.
    *
    * @return array Searched DealSource.
    */
-  public function get($id)
+  public function get($id, array $options = array())
   {
-    list($code, $deal_source) = $this->httpClient->get("/deal_sources/{$id}");
+    list($code, $deal_source) = $this->httpClient->get("/deal_sources/{$id}", null, $options);
     return $deal_source;
   }
 
@@ -96,14 +99,15 @@ class DealSourcesService
    *
    * @param integer $id Unique identifier of a DealSource
    * @param array $dealSource This array's attributes describe the object to be updated.
+   * @param array $options Additional request's options.
    *
    * @return array The resulting object representing updated resource.
    */
-  public function update($id, array $dealSource)
+  public function update($id, array $dealSource, array $options = array())
   {
     $attributes = array_intersect_key($dealSource, array_flip(self::$keysToPersist));
 
-    list($code, $updatedDealSource) = $this->httpClient->put("/deal_sources/{$id}", $attributes);
+    list($code, $updatedDealSource) = $this->httpClient->put("/deal_sources/{$id}", $attributes, $options);
     return $updatedDealSource;
   }
 
@@ -117,12 +121,13 @@ class DealSourcesService
    * This operation cannot be undone
    *
    * @param integer $id Unique identifier of a DealSource
+   * @param array $options Additional request's options.
    *
    * @return boolean Status of the operation.
    */
-  public function destroy($id)
+  public function destroy($id, array $options = array())
   {
-    list($code, $payload) = $this->httpClient->delete("/deal_sources/{$id}");
+    list($code, $payload) = $this->httpClient->delete("/deal_sources/{$id}", null, $options);
     return $code == 204;
   }
 }

--- a/lib/DealUnqualifiedReasonsService.php
+++ b/lib/DealUnqualifiedReasonsService.php
@@ -33,13 +33,14 @@ class DealUnqualifiedReasonsService
    *
    * Returns all deal unqualified reasons available to the user according to the parameters provided
    *
-   * @param array $options Search options
+   * @param array $params Search options
+   * @param array $options Additional request's options.
    *
    * @return array The list of DealUnqualifiedReasons for the first page, unless otherwise specified.
    */
-  public function all($options = [])
+  public function all($params = [], array $options = array())
   {
-    list($code, $deal_unqualified_reasons) = $this->httpClient->get("/deal_unqualified_reasons", $options);
+    list($code, $deal_unqualified_reasons) = $this->httpClient->get("/deal_unqualified_reasons", $params, $options);
     return $deal_unqualified_reasons;
   }
 
@@ -54,14 +55,15 @@ class DealUnqualifiedReasonsService
    * </figure>
    *
    * @param array $dealUnqualifiedReason This array's attributes describe the object to be created.
+   * @param array $options Additional request's options.
    *
    * @return array The resulting object representing created resource.
    */
-  public function create(array $dealUnqualifiedReason)
+  public function create(array $dealUnqualifiedReason, array $options = array())
   {
     $attributes = array_intersect_key($dealUnqualifiedReason, array_flip(self::$keysToPersist));
 
-    list($code, $createdDealUnqualifiedReason) = $this->httpClient->post("/deal_unqualified_reasons", $attributes);
+    list($code, $createdDealUnqualifiedReason) = $this->httpClient->post("/deal_unqualified_reasons", $attributes, $options);
     return $createdDealUnqualifiedReason;
   }
 
@@ -74,12 +76,13 @@ class DealUnqualifiedReasonsService
    * If a loss reason with the supplied unique identifier does not exist, it returns an error
    *
    * @param integer $id Unique identifier of a DealUnqualifiedReason
+   * @param array $options Additional request's options.
    *
    * @return array Searched DealUnqualifiedReason.
    */
-  public function get($id)
+  public function get($id, array $options = array())
   {
-    list($code, $deal_unqualified_reason) = $this->httpClient->get("/deal_unqualified_reasons/{$id}");
+    list($code, $deal_unqualified_reason) = $this->httpClient->get("/deal_unqualified_reasons/{$id}", null, $options);
     return $deal_unqualified_reason;
   }
 
@@ -96,14 +99,15 @@ class DealUnqualifiedReasonsService
    *
    * @param integer $id Unique identifier of a DealUnqualifiedReason
    * @param array $dealUnqualifiedReason This array's attributes describe the object to be updated.
+   * @param array $options Additional request's options.
    *
    * @return array The resulting object representing updated resource.
    */
-  public function update($id, array $dealUnqualifiedReason)
+  public function update($id, array $dealUnqualifiedReason, array $options = array())
   {
     $attributes = array_intersect_key($dealUnqualifiedReason, array_flip(self::$keysToPersist));
 
-    list($code, $updatedDealUnqualifiedReason) = $this->httpClient->put("/deal_unqualified_reasons/{$id}", $attributes);
+    list($code, $updatedDealUnqualifiedReason) = $this->httpClient->put("/deal_unqualified_reasons/{$id}", $attributes, $options);
     return $updatedDealUnqualifiedReason;
   }
 
@@ -117,12 +121,13 @@ class DealUnqualifiedReasonsService
    * This operation cannot be undone
    *
    * @param integer $id Unique identifier of a DealUnqualifiedReason
+   * @param array $options Additional request's options.
    *
    * @return boolean Status of the operation.
    */
-  public function destroy($id)
+  public function destroy($id, array $options = array())
   {
-    list($code, $payload) = $this->httpClient->delete("/deal_unqualified_reasons/{$id}");
+    list($code, $payload) = $this->httpClient->delete("/deal_unqualified_reasons/{$id}", null, $options);
     return $code == 204;
   }
 }

--- a/lib/DealsService.php
+++ b/lib/DealsService.php
@@ -33,13 +33,17 @@ class DealsService
    *
    * Returns all deals available to the user according to the parameters provided
    *
-   * @param array $options Search options
+   * @param array $params Search options
+   * @param array $options Additional request's options.
    *
    * @return array The list of Deals for the first page, unless otherwise specified.
    */
-  public function all($options = [])
+  public function all($params = [], array $options = array())
   {
-    list($code, $deals) = $this->httpClient->get("/deals", $options);
+    list($code, $deals) = $this->httpClient->get("/deals", $params, $options);
+    if (isset($options['raw']) && $options['raw']) {
+      return $deals;
+    }
     $dealsData = array_map(array($this, 'coerceNestedDealData'), $deals);
     return $dealsData;
   }
@@ -52,16 +56,19 @@ class DealsService
    * Create a new deal
    *
    * @param array $deal This array's attributes describe the object to be created.
+   * @param array $options Additional request's options.
    *
    * @return array The resulting object representing created resource.
    */
-  public function create(array $deal)
+  public function create(array $deal, array $options = array())
   {
     $attributes = array_intersect_key($deal, array_flip(self::$keysToPersist));
     if (isset($attributes['custom_fields']) && empty($attributes['custom_fields'])) unset($attributes['custom_fields']);
- 
     if (isset($attributes['value'])) $attributes["value"] = Coercion::toStringValue($attributes['value']);
-    list($code, $createdDeal) = $this->httpClient->post("/deals", $attributes);
+    list($code, $createdDeal) = $this->httpClient->post("/deals", $attributes, $options);
+    if (isset($options['raw']) && $options['raw']) {
+      return $createdDeal;
+    }
     $createdDeal = $this->coerceDealData($createdDeal);
     return $createdDeal;
   }
@@ -75,12 +82,16 @@ class DealsService
    * If the specified deal does not exist, the request will return an error
    *
    * @param integer $id Unique identifier of a Deal
+   * @param array $options Additional request's options.
    *
    * @return array Searched Deal.
    */
-  public function get($id)
+  public function get($id, array $options = array())
   {
-    list($code, $deal) = $this->httpClient->get("/deals/{$id}");
+    list($code, $deal) = $this->httpClient->get("/deals/{$id}", null, $options);
+    if (isset($options['raw']) && $options['raw']) {
+      return $deal;
+    }
     $deal = $this->coerceDealData($deal);
     return $deal;
   }
@@ -99,16 +110,20 @@ class DealsService
    *
    * @param integer $id Unique identifier of a Deal
    * @param array $deal This array's attributes describe the object to be updated.
+   * @param array $options Additional request's options.
    *
    * @return array The resulting object representing updated resource.
    */
-  public function update($id, array $deal)
+  public function update($id, array $deal, array $options = array())
   {
     $attributes = array_intersect_key($deal, array_flip(self::$keysToPersist));
     if (isset($attributes['custom_fields']) && empty($attributes['custom_fields'])) unset($attributes['custom_fields']);
     if (isset($attributes["value"])) $attributes["value"] = Coercion::toStringValue($attributes['value']);
 
-    list($code, $updatedDeal) = $this->httpClient->put("/deals/{$id}", $attributes);
+    list($code, $updatedDeal) = $this->httpClient->put("/deals/{$id}", $attributes, $options);
+    if (isset($options['raw']) && $options['raw']) {
+      return $updatedDeal;
+    }
     $updatedDeal = $this->coerceDealData($updatedDeal);
     return $updatedDeal;
   }
@@ -123,12 +138,13 @@ class DealsService
    * This operation cannot be undone
    *
    * @param integer $id Unique identifier of a Deal
+   * @param array $options Additional request's options.
    *
    * @return boolean Status of the operation.
    */
-  public function destroy($id)
+  public function destroy($id, array $options = array())
   {
-    list($code, $payload) = $this->httpClient->delete("/deals/{$id}");
+    list($code, $payload) = $this->httpClient->delete("/deals/{$id}", null, $options);
     return $code == 204;
   }
 

--- a/lib/LeadSourcesService.php
+++ b/lib/LeadSourcesService.php
@@ -33,13 +33,14 @@ class LeadSourcesService
    *
    * Returns all lead sources available to the user according to the parameters provided
    *
-   * @param array $options Search options
+   * @param array $params Search options
+   * @param array $options Additional request's options.
    *
    * @return array The list of LeadSources for the first page, unless otherwise specified.
    */
-  public function all($options = [])
+  public function all($params = [], array $options = array())
   {
-    list($code, $lead_sources) = $this->httpClient->get("/lead_sources", $options);
+    list($code, $lead_sources) = $this->httpClient->get("/lead_sources", $params, $options);
     return $lead_sources;
   }
 
@@ -54,14 +55,15 @@ class LeadSourcesService
    * </figure>
    *
    * @param array $leadSource This array's attributes describe the object to be created.
+   * @param array $options Additional request's options.
    *
    * @return array The resulting object representing created resource.
    */
-  public function create(array $leadSource)
+  public function create(array $leadSource, array $options = array())
   {
     $attributes = array_intersect_key($leadSource, array_flip(self::$keysToPersist));
 
-    list($code, $createdLeadSource) = $this->httpClient->post("/lead_sources", $attributes);
+    list($code, $createdLeadSource) = $this->httpClient->post("/lead_sources", $attributes, $options);
     return $createdLeadSource;
   }
 
@@ -74,12 +76,13 @@ class LeadSourcesService
    * If a source with the supplied unique identifier does not exist it returns an error
    *
    * @param integer $id Unique identifier of a LeadSource
+   * @param array $options Additional request's options.
    *
    * @return array Searched LeadSource.
    */
-  public function get($id)
+  public function get($id, array $options = array())
   {
-    list($code, $lead_source) = $this->httpClient->get("/lead_sources/{$id}");
+    list($code, $lead_source) = $this->httpClient->get("/lead_sources/{$id}", null, $options);
     return $lead_source;
   }
 
@@ -96,14 +99,15 @@ class LeadSourcesService
    *
    * @param integer $id Unique identifier of a LeadSource
    * @param array $leadSource This array's attributes describe the object to be updated.
+   * @param array $options Additional request's options.
    *
    * @return array The resulting object representing updated resource.
    */
-  public function update($id, array $leadSource)
+  public function update($id, array $leadSource, array $options = array())
   {
     $attributes = array_intersect_key($leadSource, array_flip(self::$keysToPersist));
 
-    list($code, $updatedLeadSource) = $this->httpClient->put("/lead_sources/{$id}", $attributes);
+    list($code, $updatedLeadSource) = $this->httpClient->put("/lead_sources/{$id}", $attributes, $options);
     return $updatedLeadSource;
   }
 
@@ -117,12 +121,13 @@ class LeadSourcesService
    * This operation cannot be undone
    *
    * @param integer $id Unique identifier of a LeadSource
+   * @param array $options Additional request's options.
    *
    * @return boolean Status of the operation.
    */
-  public function destroy($id)
+  public function destroy($id, array $options = array())
   {
-    list($code, $payload) = $this->httpClient->delete("/lead_sources/{$id}");
+    list($code, $payload) = $this->httpClient->delete("/lead_sources/{$id}", null, $options);
     return $code == 204;
   }
 }

--- a/lib/LeadUnqualifiedReasonsService.php
+++ b/lib/LeadUnqualifiedReasonsService.php
@@ -30,13 +30,14 @@ class LeadUnqualifiedReasonsService
    *
    * Returns all lead unqualified reasons available to the user according to the parameters provided
    *
-   * @param array $options Search options
+   * @param array $params Search options
+   * @param array $options Additional request's options.
    *
    * @return array The list of LeadUnqualifiedReasons for the first page, unless otherwise specified.
    */
-  public function all($options = [])
+  public function all($params = [], array $options = array())
   {
-    list($code, $lead_unqualified_reasons) = $this->httpClient->get("/lead_unqualified_reasons", $options);
+    list($code, $lead_unqualified_reasons) = $this->httpClient->get("/lead_unqualified_reasons", $params, $options);
     return $lead_unqualified_reasons;
   }
 }

--- a/lib/LeadsService.php
+++ b/lib/LeadsService.php
@@ -33,13 +33,14 @@ class LeadsService
    *
    * Returns all leads available to the user, according to the parameters provided
    *
-   * @param array $options Search options
+   * @param array $params Search options
+   * @param array $options Additional request's options.
    *
    * @return array The list of Leads for the first page, unless otherwise specified.
    */
-  public function all($options = [])
+  public function all($params = [], array $options = array())
   {
-    list($code, $leads) = $this->httpClient->get("/leads", $options);
+    list($code, $leads) = $this->httpClient->get("/leads", $params, $options);
     return $leads;
   }
 
@@ -52,15 +53,16 @@ class LeadsService
    * A lead may represent a single individual or an organization
    *
    * @param array $lead This array's attributes describe the object to be created.
+   * @param array $options Additional request's options.
    *
    * @return array The resulting object representing created resource.
    */
-  public function create(array $lead)
+  public function create(array $lead, array $options = array())
   {
     $attributes = array_intersect_key($lead, array_flip(self::$keysToPersist));
     if (isset($attributes['custom_fields']) && empty($attributes['custom_fields'])) unset($attributes['custom_fields']);
- 
-    list($code, $createdLead) = $this->httpClient->post("/leads", $attributes);
+
+    list($code, $createdLead) = $this->httpClient->post("/leads", $attributes, $options);
     return $createdLead;
   }
 
@@ -73,12 +75,13 @@ class LeadsService
    * If the specified lead does not exist, this query returns an error
    *
    * @param integer $id Unique identifier of a Lead
+   * @param array $options Additional request's options.
    *
    * @return array Searched Lead.
    */
-  public function get($id)
+  public function get($id, array $options = array())
   {
-    list($code, $lead) = $this->httpClient->get("/leads/{$id}");
+    list($code, $lead) = $this->httpClient->get("/leads/{$id}", null, $options);
     return $lead;
   }
 
@@ -96,15 +99,16 @@ class LeadsService
    *
    * @param integer $id Unique identifier of a Lead
    * @param array $lead This array's attributes describe the object to be updated.
+   * @param array $options Additional request's options.
    *
    * @return array The resulting object representing updated resource.
    */
-  public function update($id, array $lead)
+  public function update($id, array $lead, array $options = array())
   {
     $attributes = array_intersect_key($lead, array_flip(self::$keysToPersist));
     if (isset($attributes['custom_fields']) && empty($attributes['custom_fields'])) unset($attributes['custom_fields']);
- 
-    list($code, $updatedLead) = $this->httpClient->put("/leads/{$id}", $attributes);
+
+    list($code, $updatedLead) = $this->httpClient->put("/leads/{$id}", $attributes, $options);
     return $updatedLead;
   }
 
@@ -118,12 +122,13 @@ class LeadsService
    * This operation cannot be undone
    *
    * @param integer $id Unique identifier of a Lead
+   * @param array $options Additional request's options.
    *
    * @return boolean Status of the operation.
    */
-  public function destroy($id)
+  public function destroy($id, array $options = array())
   {
-    list($code, $payload) = $this->httpClient->delete("/leads/{$id}");
+    list($code, $payload) = $this->httpClient->delete("/leads/{$id}", null, $options);
     return $code == 204;
   }
 }

--- a/lib/LineItemsService.php
+++ b/lib/LineItemsService.php
@@ -34,13 +34,14 @@ class LineItemsService
    * Returns all line items associated to order
    *
    * @param integer $order_id Unique identifier of a Order
-   * @param array $options Search options
+   * @param array $params Search options
+   * @param array $options Additional request's options.
    *
    * @return array The list of LineItems for the first page, unless otherwise specified.
    */
-  public function all($order_id, $options = [])
+  public function all($order_id, $params = [], array $options = array())
   {
-    list($code, $line_items) = $this->httpClient->get("/orders/{$order_id}/line_items", $options);
+    list($code, $line_items) = $this->httpClient->get("/orders/{$order_id}/line_items", $params, $options);
     return $line_items;
   }
 
@@ -55,14 +56,15 @@ class LineItemsService
    *
    * @param integer $order_id Unique identifier of a Order
    * @param array $lineItem This array's attributes describe the object to be created.
+   * @param array $options Additional request's options.
    *
    * @return array The resulting object representing created resource.
    */
-  public function create($order_id, array $lineItem)
+  public function create($order_id, array $lineItem, array $options = array())
   {
     $attributes = array_intersect_key($lineItem, array_flip(self::$keysToPersist));
 
-    list($code, $createdLineItem) = $this->httpClient->post("/orders/{$order_id}/line_items", $attributes);
+    list($code, $createdLineItem) = $this->httpClient->post("/orders/{$order_id}/line_items", $attributes, $options);
     return $createdLineItem;
   }
 
@@ -75,12 +77,13 @@ class LineItemsService
    *
    * @param integer $order_id Unique identifier of a Order
    * @param integer $id Unique identifier of a LineItem
+   * @param array $options Additional request's options.
    *
    * @return array Searched LineItem.
    */
-  public function get($order_id, $id)
+  public function get($order_id, $id, array $options = array())
   {
-    list($code, $line_item) = $this->httpClient->get("/orders/{$order_id}/line_items/{$id}");
+    list($code, $line_item) = $this->httpClient->get("/orders/{$order_id}/line_items/{$id}", null, $options);
     return $line_item;
   }
 
@@ -94,12 +97,13 @@ class LineItemsService
    *
    * @param integer $order_id Unique identifier of a Order
    * @param integer $id Unique identifier of a LineItem
+   * @param array $options Additional request's options.
    *
    * @return boolean Status of the operation.
    */
-  public function destroy($order_id, $id)
+  public function destroy($order_id, $id, array $options = array())
   {
-    list($code, $payload) = $this->httpClient->delete("/orders/{$order_id}/line_items/{$id}");
+    list($code, $payload) = $this->httpClient->delete("/orders/{$order_id}/line_items/{$id}", null, $options);
     return $code == 204;
   }
 }

--- a/lib/LossReasonsService.php
+++ b/lib/LossReasonsService.php
@@ -33,13 +33,14 @@ class LossReasonsService
    *
    * Returns all deal loss reasons available to the user according to the parameters provided
    *
-   * @param array $options Search options
+   * @param array $params Search options
+   * @param array $options Additional request's options.
    *
    * @return array The list of LossReasons for the first page, unless otherwise specified.
    */
-  public function all($options = [])
+  public function all($params = [], array $options = array())
   {
-    list($code, $loss_reasons) = $this->httpClient->get("/loss_reasons", $options);
+    list($code, $loss_reasons) = $this->httpClient->get("/loss_reasons", $params, $options);
     return $loss_reasons;
   }
 
@@ -54,14 +55,15 @@ class LossReasonsService
    * </figure>
    *
    * @param array $lossReason This array's attributes describe the object to be created.
+   * @param array $options Additional request's options.
    *
    * @return array The resulting object representing created resource.
    */
-  public function create(array $lossReason)
+  public function create(array $lossReason, array $options = array())
   {
     $attributes = array_intersect_key($lossReason, array_flip(self::$keysToPersist));
 
-    list($code, $createdLossReason) = $this->httpClient->post("/loss_reasons", $attributes);
+    list($code, $createdLossReason) = $this->httpClient->post("/loss_reasons", $attributes, $options);
     return $createdLossReason;
   }
 
@@ -74,12 +76,13 @@ class LossReasonsService
    * If a loss reason with the supplied unique identifier does not exist, it returns an error
    *
    * @param integer $id Unique identifier of a LossReason
+   * @param array $options Additional request's options.
    *
    * @return array Searched LossReason.
    */
-  public function get($id)
+  public function get($id, array $options = array())
   {
-    list($code, $loss_reason) = $this->httpClient->get("/loss_reasons/{$id}");
+    list($code, $loss_reason) = $this->httpClient->get("/loss_reasons/{$id}", null, $options);
     return $loss_reason;
   }
 
@@ -96,14 +99,15 @@ class LossReasonsService
    *
    * @param integer $id Unique identifier of a LossReason
    * @param array $lossReason This array's attributes describe the object to be updated.
+   * @param array $options Additional request's options.
    *
    * @return array The resulting object representing updated resource.
    */
-  public function update($id, array $lossReason)
+  public function update($id, array $lossReason, array $options = array())
   {
     $attributes = array_intersect_key($lossReason, array_flip(self::$keysToPersist));
 
-    list($code, $updatedLossReason) = $this->httpClient->put("/loss_reasons/{$id}", $attributes);
+    list($code, $updatedLossReason) = $this->httpClient->put("/loss_reasons/{$id}", $attributes, $options);
     return $updatedLossReason;
   }
 
@@ -117,12 +121,13 @@ class LossReasonsService
    * This operation cannot be undone
    *
    * @param integer $id Unique identifier of a LossReason
+   * @param array $options Additional request's options.
    *
    * @return boolean Status of the operation.
    */
-  public function destroy($id)
+  public function destroy($id, array $options = array())
   {
-    list($code, $payload) = $this->httpClient->delete("/loss_reasons/{$id}");
+    list($code, $payload) = $this->httpClient->delete("/loss_reasons/{$id}", null, $options);
     return $code == 204;
   }
 }

--- a/lib/NotesService.php
+++ b/lib/NotesService.php
@@ -33,13 +33,14 @@ class NotesService
    *
    * Returns all notes available to the user, according to the parameters provided
    *
-   * @param array $options Search options
+   * @param array $params Search options
+   * @param array $options Additional request's options.
    *
    * @return array The list of Notes for the first page, unless otherwise specified.
    */
-  public function all($options = [])
+  public function all($params = [], array $options = array())
   {
-    list($code, $notes) = $this->httpClient->get("/notes", $options);
+    list($code, $notes) = $this->httpClient->get("/notes", $params, $options);
     return $notes;
   }
 
@@ -54,14 +55,15 @@ class NotesService
    * * [Deals](/docs/rest/reference/deals)
    *
    * @param array $note This array's attributes describe the object to be created.
+   * @param array $options Additional request's options.
    *
    * @return array The resulting object representing created resource.
    */
-  public function create(array $note)
+  public function create(array $note, array $options = array())
   {
     $attributes = array_intersect_key($note, array_flip(self::$keysToPersist));
 
-    list($code, $createdNote) = $this->httpClient->post("/notes", $attributes);
+    list($code, $createdNote) = $this->httpClient->post("/notes", $attributes, $options);
     return $createdNote;
   }
 
@@ -74,12 +76,13 @@ class NotesService
    * If the note ID does not exist, this request will return an error
    *
    * @param integer $id Unique identifier of a Note
+   * @param array $options Additional request's options.
    *
    * @return array Searched Note.
    */
-  public function get($id)
+  public function get($id, array $options = array())
   {
-    list($code, $note) = $this->httpClient->get("/notes/{$id}");
+    list($code, $note) = $this->httpClient->get("/notes/{$id}", null, $options);
     return $note;
   }
 
@@ -93,14 +96,15 @@ class NotesService
    *
    * @param integer $id Unique identifier of a Note
    * @param array $note This array's attributes describe the object to be updated.
+   * @param array $options Additional request's options.
    *
    * @return array The resulting object representing updated resource.
    */
-  public function update($id, array $note)
+  public function update($id, array $note, array $options = array())
   {
     $attributes = array_intersect_key($note, array_flip(self::$keysToPersist));
 
-    list($code, $updatedNote) = $this->httpClient->put("/notes/{$id}", $attributes);
+    list($code, $updatedNote) = $this->httpClient->put("/notes/{$id}", $attributes, $options);
     return $updatedNote;
   }
 
@@ -114,12 +118,13 @@ class NotesService
    * This operation cannot be undone
    *
    * @param integer $id Unique identifier of a Note
+   * @param array $options Additional request's options.
    *
    * @return boolean Status of the operation.
    */
-  public function destroy($id)
+  public function destroy($id, array $options = array())
   {
-    list($code, $payload) = $this->httpClient->delete("/notes/{$id}");
+    list($code, $payload) = $this->httpClient->delete("/notes/{$id}", null, $options);
     return $code == 204;
   }
 }

--- a/lib/OrdersService.php
+++ b/lib/OrdersService.php
@@ -33,13 +33,14 @@ class OrdersService
    *
    * Returns all orders available to the user according to the parameters provided
    *
-   * @param array $options Search options
+   * @param array $params Search options
+   * @param array $options Additional request's options.
    *
    * @return array The list of Orders for the first page, unless otherwise specified.
    */
-  public function all($options = [])
+  public function all($params = [], array $options = array())
   {
-    list($code, $orders) = $this->httpClient->get("/orders", $options);
+    list($code, $orders) = $this->httpClient->get("/orders", $params, $options);
     return $orders;
   }
 
@@ -53,14 +54,15 @@ class OrdersService
    * Each deal can have at most one order and error is returned when attempting to create more
    *
    * @param array $order This array's attributes describe the object to be created.
+   * @param array $options Additional request's options.
    *
    * @return array The resulting object representing created resource.
    */
-  public function create(array $order)
+  public function create(array $order, array $options = array())
   {
     $attributes = array_intersect_key($order, array_flip(self::$keysToPersist));
 
-    list($code, $createdOrder) = $this->httpClient->post("/orders", $attributes);
+    list($code, $createdOrder) = $this->httpClient->post("/orders", $attributes, $options);
     return $createdOrder;
   }
 
@@ -73,12 +75,13 @@ class OrdersService
    * If the specified order does not exist, the request will return an error
    *
    * @param integer $id Unique identifier of a Order
+   * @param array $options Additional request's options.
    *
    * @return array Searched Order.
    */
-  public function get($id)
+  public function get($id, array $options = array())
   {
-    list($code, $order) = $this->httpClient->get("/orders/{$id}");
+    list($code, $order) = $this->httpClient->get("/orders/{$id}", null, $options);
     return $order;
   }
 
@@ -92,14 +95,15 @@ class OrdersService
    *
    * @param integer $id Unique identifier of a Order
    * @param array $order This array's attributes describe the object to be updated.
+   * @param array $options Additional request's options.
    *
    * @return array The resulting object representing updated resource.
    */
-  public function update($id, array $order)
+  public function update($id, array $order, array $options = array())
   {
     $attributes = array_intersect_key($order, array_flip(self::$keysToPersist));
 
-    list($code, $updatedOrder) = $this->httpClient->put("/orders/{$id}", $attributes);
+    list($code, $updatedOrder) = $this->httpClient->put("/orders/{$id}", $attributes, $options);
     return $updatedOrder;
   }
 
@@ -113,12 +117,13 @@ class OrdersService
    * This operation cannot be undone
    *
    * @param integer $id Unique identifier of a Order
+   * @param array $options Additional request's options.
    *
    * @return boolean Status of the operation.
    */
-  public function destroy($id)
+  public function destroy($id, array $options = array())
   {
-    list($code, $payload) = $this->httpClient->delete("/orders/{$id}");
+    list($code, $payload) = $this->httpClient->delete("/orders/{$id}", null, $options);
     return $code == 204;
   }
 }

--- a/lib/PipelinesService.php
+++ b/lib/PipelinesService.php
@@ -30,13 +30,14 @@ class PipelinesService
    *
    * Returns all pipelines available to the user, according to the parameters provided
    *
-   * @param array $options Search options
+   * @param array $params Search options
+   * @param array $options Additional request's options.
    *
    * @return array The list of Pipelines for the first page, unless otherwise specified.
    */
-  public function all($options = [])
+  public function all($params = [], array $options = array())
   {
-    list($code, $pipelines) = $this->httpClient->get("/pipelines", $options);
+    list($code, $pipelines) = $this->httpClient->get("/pipelines", $params, $options);
     return $pipelines;
   }
 }

--- a/lib/ProductsService.php
+++ b/lib/ProductsService.php
@@ -33,13 +33,14 @@ class ProductsService
    *
    * Returns all products available to the user according to the parameters provided
    *
-   * @param array $options Search options
+   * @param array $params Search options
+   * @param array $options Additional request's options.
    *
    * @return array The list of Products for the first page, unless otherwise specified.
    */
-  public function all($options = [])
+  public function all($params = [], array $options = array())
   {
-    list($code, $products) = $this->httpClient->get("/products", $options);
+    list($code, $products) = $this->httpClient->get("/products", $params, $options);
     return $products;
   }
 
@@ -51,14 +52,15 @@ class ProductsService
    * Create a new product
    *
    * @param array $product This array's attributes describe the object to be created.
+   * @param array $options Additional request's options.
    *
    * @return array The resulting object representing created resource.
    */
-  public function create(array $product)
+  public function create(array $product, array $options = array())
   {
     $attributes = array_intersect_key($product, array_flip(self::$keysToPersist));
 
-    list($code, $createdProduct) = $this->httpClient->post("/products", $attributes);
+    list($code, $createdProduct) = $this->httpClient->post("/products", $attributes, $options);
     return $createdProduct;
   }
 
@@ -71,12 +73,13 @@ class ProductsService
    * If the specified product does not exist, the request will return an error
    *
    * @param integer $id Unique identifier of a Product
+   * @param array $options Additional request's options.
    *
    * @return array Searched Product.
    */
-  public function get($id)
+  public function get($id, array $options = array())
   {
-    list($code, $product) = $this->httpClient->get("/products/{$id}");
+    list($code, $product) = $this->httpClient->get("/products/{$id}", null, $options);
     return $product;
   }
 
@@ -93,14 +96,15 @@ class ProductsService
    *
    * @param integer $id Unique identifier of a Product
    * @param array $product This array's attributes describe the object to be updated.
+   * @param array $options Additional request's options.
    *
    * @return array The resulting object representing updated resource.
    */
-  public function update($id, array $product)
+  public function update($id, array $product, array $options = array())
   {
     $attributes = array_intersect_key($product, array_flip(self::$keysToPersist));
 
-    list($code, $updatedProduct) = $this->httpClient->put("/products/{$id}", $attributes);
+    list($code, $updatedProduct) = $this->httpClient->put("/products/{$id}", $attributes, $options);
     return $updatedProduct;
   }
 
@@ -116,12 +120,13 @@ class ProductsService
    * Products can be removed only by an account administrator
    *
    * @param integer $id Unique identifier of a Product
+   * @param array $options Additional request's options.
    *
    * @return boolean Status of the operation.
    */
-  public function destroy($id)
+  public function destroy($id, array $options = array())
   {
-    list($code, $payload) = $this->httpClient->delete("/products/{$id}");
+    list($code, $payload) = $this->httpClient->delete("/products/{$id}", null, $options);
     return $code == 204;
   }
 }

--- a/lib/SourcesService.php
+++ b/lib/SourcesService.php
@@ -33,13 +33,14 @@ class SourcesService
    *
    * Returns all deal sources available to the user according to the parameters provided
    *
-   * @param array $options Search options
+   * @param array $params Search options
+   * @param array $options Additional request's options.
    *
    * @return array The list of Sources for the first page, unless otherwise specified.
    */
-  public function all($options = [])
+  public function all($params = [], array $options = array())
   {
-    list($code, $sources) = $this->httpClient->get("/sources", $options);
+    list($code, $sources) = $this->httpClient->get("/sources", $params, $options);
     return $sources;
   }
 
@@ -54,14 +55,15 @@ class SourcesService
    * </figure>
    *
    * @param array $source This array's attributes describe the object to be created.
+   * @param array $options Additional request's options.
    *
    * @return array The resulting object representing created resource.
    */
-  public function create(array $source)
+  public function create(array $source, array $options = array())
   {
     $attributes = array_intersect_key($source, array_flip(self::$keysToPersist));
 
-    list($code, $createdSource) = $this->httpClient->post("/sources", $attributes);
+    list($code, $createdSource) = $this->httpClient->post("/sources", $attributes, $options);
     return $createdSource;
   }
 
@@ -74,12 +76,13 @@ class SourcesService
    * If a source with the supplied unique identifier does not exist it returns an error
    *
    * @param integer $id Unique identifier of a Source
+   * @param array $options Additional request's options.
    *
    * @return array Searched Source.
    */
-  public function get($id)
+  public function get($id, array $options = array())
   {
-    list($code, $source) = $this->httpClient->get("/sources/{$id}");
+    list($code, $source) = $this->httpClient->get("/sources/{$id}", null, $options);
     return $source;
   }
 
@@ -96,14 +99,15 @@ class SourcesService
    *
    * @param integer $id Unique identifier of a Source
    * @param array $source This array's attributes describe the object to be updated.
+   * @param array $options Additional request's options.
    *
    * @return array The resulting object representing updated resource.
    */
-  public function update($id, array $source)
+  public function update($id, array $source, array $options = array())
   {
     $attributes = array_intersect_key($source, array_flip(self::$keysToPersist));
 
-    list($code, $updatedSource) = $this->httpClient->put("/sources/{$id}", $attributes);
+    list($code, $updatedSource) = $this->httpClient->put("/sources/{$id}", $attributes, null, $options);
     return $updatedSource;
   }
 
@@ -117,12 +121,13 @@ class SourcesService
    * This operation cannot be undone
    *
    * @param integer $id Unique identifier of a Source
+   * @param array $options Additional request's options.
    *
    * @return boolean Status of the operation.
    */
-  public function destroy($id)
+  public function destroy($id, array $options = array())
   {
-    list($code, $payload) = $this->httpClient->delete("/sources/{$id}");
+    list($code, $payload) = $this->httpClient->delete("/sources/{$id}", null, $options);
     return $code == 204;
   }
 }

--- a/lib/SourcesService.php
+++ b/lib/SourcesService.php
@@ -107,7 +107,7 @@ class SourcesService
   {
     $attributes = array_intersect_key($source, array_flip(self::$keysToPersist));
 
-    list($code, $updatedSource) = $this->httpClient->put("/sources/{$id}", $attributes, null, $options);
+    list($code, $updatedSource) = $this->httpClient->put("/sources/{$id}", $attributes, $options);
     return $updatedSource;
   }
 

--- a/lib/StagesService.php
+++ b/lib/StagesService.php
@@ -30,13 +30,14 @@ class StagesService
    *
    * Returns all stages available to the user, according to the parameters provided
    *
-   * @param array $options Search options
+   * @param array $params Search options
+   * @param array $options Additional request's options.
    *
    * @return array The list of Stages for the first page, unless otherwise specified.
    */
-  public function all($options = [])
+  public function all($params = [], array $options = array())
   {
-    list($code, $stages) = $this->httpClient->get("/stages", $options);
+    list($code, $stages) = $this->httpClient->get("/stages", $params, $options);
     return $stages;
   }
 }

--- a/lib/SyncService.php
+++ b/lib/SyncService.php
@@ -32,15 +32,16 @@ class SyncService
    * This is the first endpoint to call, in order to start a new synchronization session.
    *
    * @param string $deviceUUID Device's UUID for which to perform synchronization.
+   * @param array $options Additional request's options.
    *
    * @return array The resulting object representing synchronization session or null if there is nothing to synchronize.
    */
-  public function start($deviceUUID)
+  public function start($deviceUUID, array $options = array())
   {
     // @throws InvalidArgumentException
     $this->checkArgument($deviceUUID, 'deviceUUID');
 
-    list($code, $session) = $this->httpClient->post('/sync/start', null, ['headers' => $this->buildHeaders($deviceUUID)]);
+    list($code, $session) = $this->httpClient->post('/sync/start', null, array_merge($options, ['headers' => $this->buildHeaders($deviceUUID)]));
 
     if ($code == 204) return null;
     return $session;
@@ -57,20 +58,21 @@ class SyncService
    * @param string $deviceUUID Device's UUID for which to perform synchronization.
    * @param string $sessionId Unique identifier of a synchronization session.
    * @param string $queue Queue name.
+   * @param array $options Additional request's options.
    *
    * @return array The list of resources and associated meta data or an empty array if there is no more data to synchronize.
    */
-  public function fetch($deviceUUID, $sessionId, $queue = 'main')
+  public function fetch($deviceUUID, $sessionId, $queue = 'main', array $options = array())
   {
     // @throws InvalidArgumentException
     $this->checkArgument($deviceUUID, 'deviceUUID');
     $this->checkArgument($sessionId, 'sessionId');
     $this->checkArgument($queue, 'queue');
 
-    $options = [
+    $options = array_merge($options, [
       'headers' => $this->buildHeaders($deviceUUID),
       'raw' => true
-    ];
+    ]);
     list($code, $root) = $this->httpClient->get("/sync/{$sessionId}/queues/{$queue}", null, $options);
 
     if ($code == 204) return [];
@@ -87,10 +89,11 @@ class SyncService
    *
    * @param string $deviceUUID Device's UUID for which to perform synchronization.
    * @param array $ackKeys The list of acknowledgement keys.
+   * @param array $options Additional request's options.
    *
    * @return boolean Status of the operation.
    */
-  public function ack($deviceUUID, array $ackKeys)
+  public function ack($deviceUUID, array $ackKeys, array $options = array())
   {
     // @throws InvalidArgumentException
     $this->checkArgument($deviceUUID, 'deviceUUID');
@@ -99,7 +102,7 @@ class SyncService
     if (!$ackKeys) return true;
 
     $attributes = ['ack_keys' => $ackKeys];
-    list($code,) = $this->httpClient->post('/sync/ack', $attributes, ['headers' => $this->buildHeaders($deviceUUID)]);
+    list($code,) = $this->httpClient->post('/sync/ack', $attributes, array_merge($options, ['headers' => $this->buildHeaders($deviceUUID)]));
     return $code == 202;
   }
 

--- a/lib/TagsService.php
+++ b/lib/TagsService.php
@@ -33,13 +33,14 @@ class TagsService
    *
    * Returns all tags available to the user, according to the parameters provided
    *
-   * @param array $options Search options
+   * @param array $params Search options
+   * @param array $options Additional request's options.
    *
    * @return array The list of Tags for the first page, unless otherwise specified.
    */
-  public function all($options = [])
+  public function all($params = [], array $options = array())
   {
-    list($code, $tags) = $this->httpClient->get("/tags", $options);
+    list($code, $tags) = $this->httpClient->get("/tags", $params, $options);
     return $tags;
   }
 
@@ -52,14 +53,15 @@ class TagsService
    * **Notice** the tag's name **must** be unique within the scope of the resource_type
    *
    * @param array $tag This array's attributes describe the object to be created.
+   * @param array $options Additional request's options.
    *
    * @return array The resulting object representing created resource.
    */
-  public function create(array $tag)
+  public function create(array $tag, array $options = array())
   {
     $attributes = array_intersect_key($tag, array_flip(self::$keysToPersist));
 
-    list($code, $createdTag) = $this->httpClient->post("/tags", $attributes);
+    list($code, $createdTag) = $this->httpClient->post("/tags", $attributes, $options);
     return $createdTag;
   }
 
@@ -72,12 +74,13 @@ class TagsService
    * If the specified tag does not exist, this query will return an error
    *
    * @param integer $id Unique identifier of a Tag
+   * @param array $options Additional request's options.
    *
    * @return array Searched Tag.
    */
-  public function get($id)
+  public function get($id, array $options = array())
   {
-    list($code, $tag) = $this->httpClient->get("/tags/{$id}");
+    list($code, $tag) = $this->httpClient->get("/tags/{$id}", null, $options);
     return $tag;
   }
 
@@ -92,14 +95,15 @@ class TagsService
    *
    * @param integer $id Unique identifier of a Tag
    * @param array $tag This array's attributes describe the object to be updated.
+   * @param array $options Additional request's options.
    *
    * @return array The resulting object representing updated resource.
    */
-  public function update($id, array $tag)
+  public function update($id, array $tag, array $options = array())
   {
     $attributes = array_intersect_key($tag, array_flip(self::$keysToPersist));
 
-    list($code, $updatedTag) = $this->httpClient->put("/tags/{$id}", $attributes);
+    list($code, $updatedTag) = $this->httpClient->put("/tags/{$id}", $attributes, $options);
     return $updatedTag;
   }
 
@@ -114,12 +118,13 @@ class TagsService
    * This operation cannot be undone
    *
    * @param integer $id Unique identifier of a Tag
+   * @param array $options Additional request's options.
    *
    * @return boolean Status of the operation.
    */
-  public function destroy($id)
+  public function destroy($id, array $options = array())
   {
-    list($code, $payload) = $this->httpClient->delete("/tags/{$id}");
+    list($code, $payload) = $this->httpClient->delete("/tags/{$id}", null, $options);
     return $code == 204;
   }
 }

--- a/lib/TasksService.php
+++ b/lib/TasksService.php
@@ -35,13 +35,14 @@ class TasksService
    * If you ask for tasks without any parameter provided Base API will return you both **floating** and **related** tasks
    * Although you can narrow the search set to either of them via query parameters
    *
-   * @param array $options Search options
+   * @param array $params Search options
+   * @param array $options Additional request's options.
    *
    * @return array The list of Tasks for the first page, unless otherwise specified.
    */
-  public function all($options = [])
+  public function all($params = [], array $options = array())
   {
-    list($code, $tasks) = $this->httpClient->get("/tasks", $options);
+    list($code, $tasks) = $this->httpClient->get("/tasks", $params, $options);
     return $tasks;
   }
 
@@ -57,14 +58,15 @@ class TasksService
    * * [Deals](/docs/rest/reference/deals)
    *
    * @param array $task This array's attributes describe the object to be created.
+   * @param array $options Additional request's options.
    *
    * @return array The resulting object representing created resource.
    */
-  public function create(array $task)
+  public function create(array $task, array $options = array())
   {
     $attributes = array_intersect_key($task, array_flip(self::$keysToPersist));
 
-    list($code, $createdTask) = $this->httpClient->post("/tasks", $attributes);
+    list($code, $createdTask) = $this->httpClient->post("/tasks", $attributes, $options);
     return $createdTask;
   }
 
@@ -77,12 +79,13 @@ class TasksService
    * If the specified task does not exist, this query will return an error
    *
    * @param integer $id Unique identifier of a Task
+   * @param array $options Additional request's options.
    *
    * @return array Searched Task.
    */
-  public function get($id)
+  public function get($id, array $options = array())
   {
-    list($code, $task) = $this->httpClient->get("/tasks/{$id}");
+    list($code, $task) = $this->httpClient->get("/tasks/{$id}", null, $options);
     return $task;
   }
 
@@ -96,14 +99,15 @@ class TasksService
    *
    * @param integer $id Unique identifier of a Task
    * @param array $task This array's attributes describe the object to be updated.
+   * @param array $options Additional request's options.
    *
    * @return array The resulting object representing updated resource.
    */
-  public function update($id, array $task)
+  public function update($id, array $task, array $options = array())
   {
     $attributes = array_intersect_key($task, array_flip(self::$keysToPersist));
 
-    list($code, $updatedTask) = $this->httpClient->put("/tasks/{$id}", $attributes);
+    list($code, $updatedTask) = $this->httpClient->put("/tasks/{$id}", $attributes, $options);
     return $updatedTask;
   }
 
@@ -117,12 +121,13 @@ class TasksService
    * This operation cannot be undone
    *
    * @param integer $id Unique identifier of a Task
+   * @param array $options Additional request's options.
    *
    * @return boolean Status of the operation.
    */
-  public function destroy($id)
+  public function destroy($id, array $options = array())
   {
-    list($code, $payload) = $this->httpClient->delete("/tasks/{$id}");
+    list($code, $payload) = $this->httpClient->delete("/tasks/{$id}", null, $options);
     return $code == 204;
   }
 }

--- a/lib/TextMessagesService.php
+++ b/lib/TextMessagesService.php
@@ -30,13 +30,14 @@ class TextMessagesService
    *
    * Returns Text Messages, according to the parameters provided
    *
-   * @param array $options Search options
+   * @param array $params Search options
+   * @param array $options Additional request's options.
    *
    * @return array The list of TextMessages for the first page, unless otherwise specified.
    */
-  public function all($options = [])
+  public function all($params = [], array $options = array())
   {
-    list($code, $text_messages) = $this->httpClient->get("/text_messages", $options);
+    list($code, $text_messages) = $this->httpClient->get("/text_messages", $params, $options);
     return $text_messages;
   }
 
@@ -49,12 +50,13 @@ class TextMessagesService
    * If the specified user does not exist, this query returns an error
    *
    * @param integer $id Unique identifier of a TextMessage
+   * @param array $options Additional request's options.
    *
    * @return array Searched TextMessage.
    */
-  public function get($id)
+  public function get($id, array $options = array())
   {
-    list($code, $text_message) = $this->httpClient->get("/text_messages/{$id}");
+    list($code, $text_message) = $this->httpClient->get("/text_messages/{$id}", null, $options);
     return $text_message;
   }
 }

--- a/lib/UsersService.php
+++ b/lib/UsersService.php
@@ -30,13 +30,14 @@ class UsersService
    *
    * Returns all users, according to the parameters provided
    *
-   * @param array $options Search options
+   * @param array $params Search options
+   * @param array $options Additional request's options.
    *
    * @return array The list of Users for the first page, unless otherwise specified.
    */
-  public function all($options = [])
+  public function all($params = [], array $options = array())
   {
-    list($code, $users) = $this->httpClient->get("/users", $options);
+    list($code, $users) = $this->httpClient->get("/users", $params, $options);
     return $users;
   }
 
@@ -49,12 +50,13 @@ class UsersService
    * If the specified user does not exist, this query returns an error
    *
    * @param integer $id Unique identifier of a User
+   * @param array $options Additional request's options.
    *
    * @return array Searched User.
    */
-  public function get($id)
+  public function get($id, array $options = array())
   {
-    list($code, $user) = $this->httpClient->get("/users/{$id}");
+    list($code, $user) = $this->httpClient->get("/users/{$id}", null, $options);
     return $user;
   }
 
@@ -65,12 +67,13 @@ class UsersService
    *
    * Returns a single authenticating user, according to the authentication credentials provided
    *
+   * @param array $options Additional request's options.
    *
    * @return array Resource object.
    */
-  public function self()
+  public function self(array $options = array())
   {
-    list($code, $resource) = $this->httpClient->get("/users/self");
+    list($code, $resource) = $this->httpClient->get("/users/self", null, $options);
     return $resource;
   }
 }

--- a/lib/VisitOutcomesService.php
+++ b/lib/VisitOutcomesService.php
@@ -30,13 +30,14 @@ class VisitOutcomesService
    *
    * Returns Visit Outcomes, according to the parameters provided
    *
-   * @param array $options Search options
+   * @param array $params Search options
+   * @param array $options Additional request's options.
    *
    * @return array The list of VisitOutcomes for the first page, unless otherwise specified.
    */
-  public function all($options = [])
+  public function all($params = [], array $options = array())
   {
-    list($code, $visit_outcomes) = $this->httpClient->get("/visit_outcomes", $options);
+    list($code, $visit_outcomes) = $this->httpClient->get("/visit_outcomes", $params, $options);
     return $visit_outcomes;
   }
 }

--- a/lib/VisitsService.php
+++ b/lib/VisitsService.php
@@ -30,13 +30,14 @@ class VisitsService
    *
    * Returns Visits, according to the parameters provided
    *
-   * @param array $options Search options
+   * @param array $params Search options
+   * @param array $options Additional request's options.
    *
    * @return array The list of Visits for the first page, unless otherwise specified.
    */
-  public function all($options = [])
+  public function all($params = [], array $options = array())
   {
-    list($code, $visits) = $this->httpClient->get("/visits", $options);
+    list($code, $visits) = $this->httpClient->get("/visits", $params, $options);
     return $visits;
   }
 }


### PR DESCRIPTION
Changes:

* Adds $option parameter (default array[]) to all the transitive callers of \BaseCRM\HttpClient::request() in Service classes
* Avoids casting/unwrapping responses when $options['raw'] is used
* Existing $option parameters are renamed to $params for the sake of consistency

Based on https://github.com/basecrm/basecrm-php/pull/41